### PR TITLE
135 merge a first light version of massa web3 section

### DIFF
--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -1,0 +1,185 @@
+---
+id: massa-web3-main
+title: Using Massa-web3
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Leveraging Javascript API for Massa interaction
+
+## What is Massa-Web3?
+
+Massa-web3 is an exhaustive library enabling interaction with the Massa blockchain. It can be used in a browser environment and Node.js runtime.
+
+:::note
+Massa-web3 operates by utilizing JsonRPC API in the background to facilitate blockchain communication. The API is divided into a Private and a Public segment, used for node management and blockchain interactions, respectively. For more information on the API, please refer to the [JsonRPC API documentation](api/jsonrpc).
+:::
+
+Massa-web3 will allow you to interact with the Massa blockchain in a variety of ways:
+
+- Send transactions
+- Deploy smart contracts
+- Create, manage and inspect addresses
+- Manage your node
+- Fetch events from the blockchain
+- And much more!
+
+In addition, the library includes a collection of handy utility functions (e.g. to convert between different units of MASSA, etc.).
+:::tip
+For a quick integration of Massa within a web browser, consider reading our Web Frontend Integration Guide.
+:::
+
+## Installation
+
+Massa-web3 can be used as a library for frameworks or as a stand-alone bundled js file which can be easily loaded into the browser.
+
+### Requirements
+
+- NodeJS 14+
+- npm / yarn (see package.json)
+
+### As a library (Node.js/React/Vue.js)
+
+Just install the library using npm:
+
+```shell
+npm install @massalabs/massa-web3
+```
+
+### In a browser
+
+If you want to use the library in a vanilla javascript project, please add the following script tag to your html file:
+
+```html
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/@massalabs/massa-web3@x.x.x/bundle.js"
+></script>
+```
+
+whereby the x.x.x is one of the available released versions under [Massa-web3's releases page](https://github.com/massalabs/massa-web3/releases):
+
+In your code, once the script is fully loaded, just use window.massa to access all massa-web3 exports.
+
+```ts
+<script>console.log("Massa Web3 ", window.massa);</script>
+```
+
+## Usage
+
+### Initialization
+
+You can easily initialize a client instance using the ClientFactory class:
+
+<Tabs>
+<TabItem value="mainnet-client" label="Mainnet" default>
+
+```typescript
+const testnetClient: Client = await ClientFactory.createDefaultClient(
+  DefaultProviderUrls.MAINNET,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+
+<TabItem value="testnet-client" label="Testnet" default>
+
+```typescript
+const testnetClient: Client = await ClientFactory.createDefaultClient(
+  DefaultProviderUrls.TESTNET,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+
+<TabItem value="buildnet-client" label="Buildnet" default>
+
+```typescript
+const testnetClient: Client = await ClientFactory.createDefaultClient(
+  DefaultProviderUrls.BUILDNET,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+
+<TabItem value="labnet-client" label="Labnet" default>
+
+```typescript
+const testnetClient: Client = await ClientFactory.createDefaultClient(
+  DefaultProviderUrls.LABNET,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+
+<TabItem value="local-client" label="Localnet" default>
+
+```typescript
+const testnetClient: Client = await ClientFactory.createDefaultClient(
+  DefaultProviderUrls.LOCALNET,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+
+<TabItem value="custom-client" label="Custom Client">
+You can also create a custom client connecting to a node whose ip and ports are to be specified by the user.
+
+```ts
+// initialize a custom client using an own provider
+const providers: Array<IProvider> = [
+  {
+    url: "http://127.0.0.1:33035",
+    type: ProviderType.PUBLIC,
+  } as IProvider,
+  {
+    url: "http://127.0.0.1:33034",
+    type: ProviderType.PRIVATE,
+  } as IProvider,
+];
+
+const customClient: Client = await ClientFactory.createCustomClient(
+  providers,
+  true,
+  baseAccount
+);
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+Please note that specifying a base account is only optional at this point. You can learn more about how to set up a base account in the [Wallet Operations](massa-web3/massa-web3-wallet) section.
+:::
+
+Once there is an initialized client instance, it is straightforward to call methods on it:
+
+```ts
+import { IStatus, IAddressInfo } from "@massalabs/massa-web3";
+
+const addressesResp: Array<IAddressInfo> = await web3Client
+  .publicApi()
+  .getAddresses(["some_address"]);
+```
+
+### Client exposed APIs
+julienbrs marked this conversation as resolved.
+
+You can find details for each of the exposed APIs with all the available methods in the following sections:
+
+- [Public API](massa-web3/massa-web3-public-api)
+- [Private API](massa-web3/massa-web3-private-api)
+- [Wallet Operations](massa-web3/massa-web3-wallet)
+- [Smart Contracts Operations](massa-web3/massa-web3-smart-contracts)
+- [Utility Functions](massa-web3/massa-web3-utils)

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -178,8 +178,8 @@ julienbrs marked this conversation as resolved.
 
 You can find details for each of the exposed APIs with all the available methods in the following sections:
 
-- [Public API](massa-web3/massa-web3-public-api)
-- [Private API](massa-web3/massa-web3-private-api)
-- [Wallet Operations](massa-web3/massa-web3-wallet)
-- [Smart Contracts Operations](massa-web3/massa-web3-smart-contracts)
-- [Utility Functions](massa-web3/massa-web3-utils)
+- [Wallet Operations](https://web3.docs.massa.net/classes/WalletClient.html)
+- [Smart Contracts Operations](https://web3.docs.massa.net/classes/SmartContractsClient.html)
+- [Public API](https://web3.docs.massa.net/classes/PublicApiClient.html)
+- [Private API](https://web3.docs.massa.net/classes/PrivateApiClient.html)
+

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -25,7 +25,9 @@ Massa-web3 will allow you to interact with the Massa blockchain in a variety of 
 - Fetch events from the blockchain
 - And much more!
 
-In addition, the library includes a collection of handy utility functions (e.g. to convert between different units of MASSA, etc.).
+In addition, the library includes a collection of handy utility functions (e.g conversion between different units, etc)
+that you can find in the [Utils](massa-web3/massa-web3-utils) section.
+
 :::tip
 For a quick integration of Massa within a web browser, consider reading our Web Frontend Integration Guide.
 :::

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -25,8 +25,7 @@ Massa-web3 will allow you to interact with the Massa blockchain in a variety of 
 - Fetch events from the blockchain
 - And much more!
 
-In addition, the library includes a collection of handy utility functions (e.g conversion between different units, etc)
-that you can find in the [Utils](massa-web3/massa-web3-utils) section.
+In addition, the library includes a [collection of handy utility functions](massa-web3/massa-web3-utils) (e.g conversion between different units, etc).
 
 :::tip
 For a quick integration of Massa within a web browser, consider reading our Web Frontend Integration Guide.

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -160,7 +160,7 @@ const customClient: Client = await ClientFactory.createCustomClient(
 </Tabs>
 
 :::info
-Please note that specifying a base account is only optional at this point. You can learn more about how to set up a base account in the [Wallet Operations](massa-web3/massa-web3-wallet) section.
+Please note that specifying a base account is only optional at this point. You can learn more about how to set up a base account in the [Wallet Operations](https://web3.docs.massa.net/classes/WalletClient.html) section.
 :::
 
 Once there is an initialized client instance, it is straightforward to call methods on it:

--- a/docs/build/massa-web3/utils.mdx
+++ b/docs/build/massa-web3/utils.mdx
@@ -1,0 +1,45 @@
+---
+id: massa-web3-utils
+title: Utils
+---
+
+### Massa Units
+
+All Massa values that are being used or returned by web3 (gas, fees, coins and rolls) are expressed via BigInt's. Massa-web3 has however a few convenience methods and converters that might come handy. Below is a summary of available methods:
+
+- Rolls: expressed in BigInt's. For Rolls there is no metric system as rolls are unit-less. 10 rolls is to be represented by a BigInt containing 10. Example:
+
+```ts
+const rolls = BigInt(10);
+// or. ...
+const rolls = 10n;
+```
+
+- Gas/MaxGas: expressed in BigInt's. For Gas/MaxGas there is no metric system as gas is unit-less. The gas represents the computational units required for a given operation to be executed by the network. Example:
+
+```ts
+const gas = BigInt(2000000);
+// or. ...
+const gas = 2000000n;
+```
+
+- Coins/Fees: expressed in BigInt's. Coins/fees do however have a metric system behind them. The smallest unit is 10**-9 Massa. All coins/fees are to be expressed as integers scaled by 10**9 and this way consumed by the network json-rpc protocol. Since gas/fees are to be used as BigInt's web3 adds in a few convenience utils allowing smaller units (e.g. 0.5 Massa) to be expressed.
+
+The util function `fromMAS` and `toMAS` are used exactly for the latter purpose. `fromMAS` receives any amount of type `number | string | BigNumber | bigint and returns a scaled bigint` for ready use. `toMAS` on the contrary converts any amount from `nanoMassa` to `Massa` and returns a `BigNumber` representing the amount as a decimal.
+
+Examples:
+
+```ts
+const coinsToTransfer = fromMAS("0.5"); // half a massa
+// or. ...
+const coinsToTransfer = 500n * MassaUnits.mMassa; // half a massa
+const coinsToTransfer = fromMAS("1"); // one massa
+// or. ...
+const coinsToTransfer = 1n * MassaUnits.oneMassa; // one massa
+```
+
+Web3 exposes a collection `MassaUnits` which has three convenience `BigInt` constants that could be used for amount scaling:
+
+- `MassaUnits.oneMassa` = $10^{9}$
+- `MassaUnits.mMassa` = $10^{6}$
+- `MassaUnits.uMassa` = $10^{3}$

--- a/sidebars.js
+++ b/sidebars.js
@@ -203,6 +203,10 @@ const sidebars = {
           type: "doc",
           id: "build/massa-web3/massa-web3-main",
         },
+        {
+          type: "doc",
+          id: "build/massa-web3/massa-web3-utils",
+        },
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -84,12 +84,13 @@ const sidebars = {
     },
     {
       type: "html",
-      value: "<span class='menu__link'><b><small>Decentralized Web</small></b></span>"
+      value:
+        "<span class='menu__link'><b><small>Decentralized Web</small></b></span>",
     },
     {
       type: "doc",
       id: "learn/decentralized-web",
-    }
+    },
   ],
   tutorialSidebar: [
     {
@@ -191,6 +192,16 @@ const sidebars = {
         {
           type: "doc",
           id: "build/wallet/community-wallets",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Massa-Web3",
+      items: [
+        {
+          type: "doc",
+          id: "build/massa-web3/massa-web3-main",
         },
       ],
     },


### PR DESCRIPTION
closes #135
Until section of massa-web3 is completed with correct examples and examples tested with e2e tests, we should merge a first version of massa-web3 section with the quickstart, and redirecting with the typescript docs. 
I've also added the utils section. It might seems weird as it is the only additional section in the sidebar with the quickstart, but these information can't be found in the typescript documentation so I think it is useful.
This is just a transition before the final massa-web3 section