### PR TITLE
Warning storing private key for the template

### DIFF
--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -280,11 +280,10 @@ Make sure to replace `SECRET_KEY` and `SC_ADDRESS` with your own secret key and 
 :::
 
 :::caution
-Because this template is storing your secret key in plain text, it's not secure and is only used for demonstration purposes.
+This template is storing your secret key in plain text. It's not secure and is only used for demonstration purposes.
 If you want to use this template for production, you should consider using a wallet-provider to store your secret key.
 
 You can find more information about it in the [wallet-provider section](wallet/wallet-provider).
-
 :::
 
 ### Understanding the Code

--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -279,10 +279,9 @@ export default Content;
 Make sure to replace `SECRET_KEY` and `SC_ADDRESS` with your own secret key and smart contract address.
 :::
 
-:::warning
+:::caution
 Because this template is storing your secret key in plain text, it's not secure and is only used for demonstration purposes.
-Your secret key is a highly sensitive piece of information and should never be shared with anyone. If you're 
-using a public repository, make sure to add your secret key to a .env file and add it to your .gitignore file.
+If you want to use this template for production, you should consider using a wallet-provider to store your secret key.
 :::
 
 ### Understanding the Code

--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -275,8 +275,14 @@ function Content() {
 export default Content;
 ```
 
-:::caution
+:::info
 Make sure to replace `SECRET_KEY` and `SC_ADDRESS` with your own secret key and smart contract address.
+:::
+
+:::warning
+Because this template is storing your secret key in plain text, it's not secure and is only used for demonstration purposes.
+Your secret key is a highly sensitive piece of information and should never be shared with anyone. If you're 
+using a public repository, make sure to add your secret key to a .env file and add it to your .gitignore file.
 :::
 
 ### Understanding the Code

--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -282,6 +282,9 @@ Make sure to replace `SECRET_KEY` and `SC_ADDRESS` with your own secret key and 
 :::caution
 Because this template is storing your secret key in plain text, it's not secure and is only used for demonstration purposes.
 If you want to use this template for production, you should consider using a wallet-provider to store your secret key.
+
+You can find more information about it in the [wallet-provider section](wallet/wallet-provider).
+
 :::
 
 ### Understanding the Code


### PR DESCRIPTION
closes #134
I used the `:::warning:::` docusaurus flag to wrap the message, maybe it appears too aggressive ?