### PR TITLE
Add providers API version

### DIFF
--- a/docs/build/api/grpc.mdx
+++ b/docs/build/api/grpc.mdx
@@ -14,13 +14,6 @@ The Massa JSON-RPC API is splitted in two parts:
 - **Private API**: used for node management. Default port: 33038 e.g.
     <grpc://localhost:33038>
 
-Find the complete Massa gRPC specification
-[here](https://github.com/massalabs/massa-proto/tree/main/proto/apis/massa/api/v1).
-
-The [API](https://htmlpreview.github.io/?https://github.com/massalabs/massa-proto/blob/main/doc/api.html) and
-[Commons](https://htmlpreview.github.io/?https://github.com/massalabs/massa-proto/blob/main/doc/commons.html)
-provide details on all available messages and methods in the gRPC Massa services.
-
 :::info
 To enable events (blocks, endorsements, operations...) brodcast via gRPC streams in your Massa node, add or edit the file
 `massa-node/config/config.toml` with the following content:
@@ -31,6 +24,12 @@ To enable events (blocks, endorsements, operations...) brodcast via gRPC streams
    enable_broadcast = true
 ```
 :::
+
+## Documentation
+
+- gRPC **API** [documentation](https://htmlpreview.github.io/?https://github.com/massalabs/massa-proto/blob/main/doc/api.html).
+- gRPC **Commons** [documentation](https://htmlpreview.github.io/?https://github.com/massalabs/massa-proto/blob/main/doc/commons.html).
+- gRPC **API** [specification](https://github.com/massalabs/massa-proto/tree/main/proto/apis/massa/api/v1).
 
 ## Integrations
 

--- a/docs/build/api/grpc.mdx
+++ b/docs/build/api/grpc.mdx
@@ -44,11 +44,12 @@ To enable events (blocks, endorsements, operations...) brodcast via gRPC streams
 **Step 1: Clone `massa-proto` repository**
 
 ```shell
-git clone https://github.com/massalabs/massa-proto.git
+git clone -b MASSA_PROTO_TAG https://github.com/massalabs/massa-proto.git --depth 1
 ```
 
 :::note
-If you are using an older version of the Massa node, please use the commit hash corresponding to your node version.
+If you are using an older version of the Massa node, please use the tag version or commit hash corresponding to your node version.
+Find all `massa-proto` tags [here](https://github.com/massalabs/massa-proto/tags).
 :::
 
 **Step 2: Install Buf CLI**

--- a/docs/build/api/providers.mdx
+++ b/docs/build/api/providers.mdx
@@ -20,7 +20,6 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <th>Provider</th>
           <th>Protocol</th>
           <th>Endpoint URL</th>
-          <th>Version</th>
         </tr>
       </thead>
         <tbody>
@@ -28,13 +27,11 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://buildnet.massa.net/api/v2</code></td>
-          <td><code>24.1</code></td>
         </tr>
         <tr>
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>gRPC</code></td>
           <td><code>grpc://buildnet.massa.net:33037</code></td>
-          <td><code>24.1</code></td>
         </tr>
         </tbody>
     </table>
@@ -46,7 +43,6 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <th>Provider</th>
           <th>Protocol</th>
           <th>Endpoint URL</th>
-          <th>Version</th>
         </tr>
       </thead>
         <tbody>
@@ -54,19 +50,16 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://test.massa.net/api/v2</code></td>
-          <td><code>25.2</code></td>
         </tr>
         <tr>
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>gRPC</code></td>
           <td><code>grpc://test.massa.net:33037</code></td>
-          <td><code>25.2</code></td>
         </tr>
         <tr>
           <td><a href="https://www.altailabs.tech/">Altai Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://massexplo.io/api/node</code></td>
-          <td><code>25.2</code></td>
         </tr>
         </tbody>
     </table>

--- a/docs/build/api/providers.mdx
+++ b/docs/build/api/providers.mdx
@@ -20,6 +20,7 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <th>Provider</th>
           <th>Protocol</th>
           <th>Endpoint URL</th>
+          <th>Version</th>
         </tr>
       </thead>
         <tbody>
@@ -27,11 +28,13 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://buildnet.massa.net/api/v2</code></td>
+          <td><code>24.1</code></td>
         </tr>
         <tr>
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>gRPC</code></td>
           <td><code>grpc://buildnet.massa.net:33037</code></td>
+          <td><code>24.1</code></td>
         </tr>
         </tbody>
     </table>
@@ -43,6 +46,7 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <th>Provider</th>
           <th>Protocol</th>
           <th>Endpoint URL</th>
+          <th>Version</th>
         </tr>
       </thead>
         <tbody>
@@ -50,16 +54,19 @@ To enhance redundancy and facilitate load balancing, consider using multiple pro
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://test.massa.net/api/v2</code></td>
+          <td><code>25.2</code></td>
         </tr>
         <tr>
           <td><a href="/docs/build/networks-faucets">Massa Labs</a></td>
           <td><code>gRPC</code></td>
           <td><code>grpc://test.massa.net:33037</code></td>
+          <td><code>25.2</code></td>
         </tr>
         <tr>
           <td><a href="https://www.altailabs.tech/">Altai Labs</a></td>
           <td><code>JsonRPC</code></td>
           <td><code>https://massexplo.io/api/node</code></td>
+          <td><code>25.2</code></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Due to feedbacks from developers who are struggling with the gRPC side versioning. I tried to fix this issue by introducing tags which matches the node versions.