### PR TITLE
workaround callapsible false

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -34,7 +34,7 @@ const sidebars = {
           type: "doc",
           id: "massaStation/uninstall",
         },
-      ]
+      ],
     },
     {
       type: "doc",
@@ -98,7 +98,7 @@ const sidebars = {
     {
       type: "doc",
       id: "massaStation/hello-world-plugin",
-    }
+    },
   ],
   learnSidebar: [
     {
@@ -239,6 +239,7 @@ const sidebars = {
         },
         {
           type: "category",
+          collapsible: false,
           label: "Develop",
           items: [
             {
@@ -283,7 +284,7 @@ const sidebars = {
         {
           type: "doc",
           id: "build/wallet/wallet-provider",
-        },  
+        },
         {
           type: "doc",
           id: "build/wallet/community-wallets",
@@ -323,7 +324,7 @@ const sidebars = {
         {
           type: "doc",
           id: "build/networks-faucets/local-network",
-        }
+        },
       ],
     },
     {


### PR DESCRIPTION
# Bug description

![image](https://github.com/massalabs/docs/assets/11590067/b94ad8a2-8d73-4522-af50-f11a0273dffc)
the Develop category doesn't collapse when we click on it. And when we navigate in http://localhost:3000/docs/build/smart-contract/prerequisites is doesn't collapse neither. It looks like a bug maybe on docusaurus side because when we collapse and uncollapse the Smart Contract category, then the Develop category works.

# Proposed fix

Make the Develop category non collapsible. Open by default and impossible to collapse.
![image](https://github.com/massalabs/docs/assets/11590067/4a5b94e1-7caf-4370-bccd-1a7b99361cdc)
