### PR TITLE
Add mainnet docs + refacto node running docs

### DIFF
--- a/.github/workflows/config/link-check.json
+++ b/.github/workflows/config/link-check.json
@@ -7,7 +7,7 @@
         "pattern": "^http://manpages.ubuntu.com"
       },
       {
-        "pattern": "^https://test.massa.net/api/v2"
+        "pattern": "^https://mainnet.massa.net/api/v2"
       },
       {
         "pattern": "^https://buildnet.massa.net/api/v2"

--- a/.gitignore
+++ b/.gitignore
@@ -21,17 +21,15 @@ yarn-error.log*
 .yarn
 .pnp.*
 
-# downlaoded files
+# downloaded files
 external/client/buildnet/config.toml
-external/client/securnet/config.toml
-external/client/testnet/config.toml
+external/client/mainnet/config.toml
 external/node/buildnet/config.toml
-external/node/securnet/bootstrap_whitelist.json
-external/node/securnet/config.toml
-external/node/testnet/bootstrap_whitelist.json
-external/node/testnet/config.toml
+external/node/mainnet/bootstrap_whitelist.json
+external/node/mainnet/config.toml
 
 *.mdx-e
 
 # IDE
 .idea
+.vscode

--- a/docs/build/api/jsonrpc.mdx
+++ b/docs/build/api/jsonrpc.mdx
@@ -50,10 +50,25 @@ Summary of the current state: time, last final blocks (hash, thread,
 slot, timestamp), clique count, connected nodes count.
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_status",
+    "params": []
+}'
+```
+
+</TabItem>
+
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -174,10 +189,24 @@ Get information about the block
 of the graph.
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_cliques",
+    "params": []
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -222,10 +251,24 @@ Get information about active
 their roll counts for the current cycle.
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_stakers",
+    "params": [ {"offset": 0, "limit": 2 }]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -268,10 +311,24 @@ Get information about
 (es) (balances, block creation, \...).
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_addresses",
+    "params": [["AU12gAkmGeozFceJD4tQmbVvihYdX2KyWZcYLL8xdYZeP4EuWYdex"]]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -361,10 +418,24 @@ Get information about block graph
 within the specified time interval.
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_graph_interval",
+    "params": [{"start": 1678095527706, "end": 1678095529706}]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -447,10 +518,24 @@ Get information about [block(s)](https://docs.massa.net/docs/learn/architecture/
 associated to a given hash(s).
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_blocks",
+    "params": [["B122ByHzPVJ3QFwmuYcZ4vZYzq6rfkqx7BJSJdFNHWp9j2o5Fpxv"]]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -551,10 +636,24 @@ Get information about
 (s) information associated to a given operation(s) ID(s).
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_operations",
+    "params": [["O1LMr9xyL9fVSbUvZao4jy6t2Pj5UPtLG8x1fxvS6SD7dPb5S52"]]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",
@@ -616,10 +715,24 @@ Get information about
 (s) (content, finality \...)
 
 <Tabs>
-<TabItem value="json" label="cURL" default>
+<TabItem value="json (Mainnet)" label="cURL (Mainnet)" default>
 
 ```shell
-curl --location --request POST 'https://test.massa.net/api/v2' \
+curl --location --request POST 'https://mainnet.massa.net/api/v2' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "get_endorsements",
+    "params": [["E12kB72Jz4iMWkVkckS2e6cUBm4e5XEW77biDjSysAWmQkNrvuJr"]]
+}'
+```
+
+</TabItem>
+<TabItem value="json (Buildnet)" label="cURL (Buildnet)">
+
+```shell
+curl --location --request POST 'https://buildnet.massa.net/api/v2' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "jsonrpc": "2.0",

--- a/docs/build/api/providers.mdx
+++ b/docs/build/api/providers.mdx
@@ -13,6 +13,30 @@ Be aware that the latency you encounter may vary depending on the provider's geo
 To enhance redundancy and facilitate load balancing, consider using multiple providers.
 
 <Tabs>
+  <TabItem value="mainnet" label="👷 MainNet" default>
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Protocol</th>
+          <th>Endpoint URL</th>
+        </tr>
+      </thead>
+        <tbody>
+        <tr>
+          <td><a href="/docs/build/networks-faucets/public-networks">Massa Labs</a></td>
+          <td><code>JsonRPC</code></td>
+          <td><code>https://mainnet.massa.net/api/v2</code></td>
+        </tr>
+        <tr>
+          <td><a href="/docs/build/networks-faucets/public-networks">Massa Labs</a></td>
+          <td><code>gRPC</code></td>
+          <td><code>grpc://mainnet.massa.net:33037</code></td>
+        </tr>
+        </tbody>
+    </table>
+  </TabItem>
+
   <TabItem value="buildnet" label="👷 BuildNet" default>
     <table>
       <thead>

--- a/docs/build/api/providers.mdx
+++ b/docs/build/api/providers.mdx
@@ -13,7 +13,7 @@ Be aware that the latency you encounter may vary depending on the provider's geo
 To enhance redundancy and facilitate load balancing, consider using multiple providers.
 
 <Tabs>
-  <TabItem value="mainnet" label="👷 MainNet" default>
+  <TabItem value="mainnet" label="🖥 MainNet" default>
     <table>
       <thead>
         <tr>

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -150,9 +150,11 @@ You can easily initialize a client instance using the ClientFactory class:
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
 );
+const chainId = CHAIN_ID.MainNet;
 
 const testnetClient: Client = await ClientFactory.createDefaultClient(
   DefaultProviderUrls.MAINNET,
+  chainId,
   true, // retry failed requests
   baseAccount // optional parameter
 );
@@ -164,9 +166,11 @@ const testnetClient: Client = await ClientFactory.createDefaultClient(
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
 );
+const chainId = CHAIN_ID.BuildNet;
 
 const testnetClient: Client = await ClientFactory.createDefaultClient(
   DefaultProviderUrls.BUILDNET,
+  chainId,
   true, // retry failed requests
   baseAccount // optional parameter
 );
@@ -179,9 +183,11 @@ const testnetClient: Client = await ClientFactory.createDefaultClient(
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
 );
+const chainId = CHAIN_ID.LabNet;
 
 const testnetClient: Client = await ClientFactory.createDefaultClient(
   DefaultProviderUrls.LABNET,
+  chainId,
   true, // retry failed requests
   baseAccount // optional parameter
 );
@@ -195,9 +201,11 @@ const testnetClient: Client = await ClientFactory.createDefaultClient(
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
 );
+const chainId = CHAIN_ID.Sandbox;
 
 const testnetClient: Client = await ClientFactory.createDefaultClient(
   DefaultProviderUrls.LOCALNET,
+  chainId,
   true, // retry failed requests
   baseAccount // optional parameter
 );
@@ -212,6 +220,7 @@ You can also create a custom client connecting to a node whose ip and ports are 
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
 );
+const chainId = CHAIN_ID.Sandbox;
 
 // initialize a custom client using an own provider
 const providers: Array<IProvider> = [
@@ -227,6 +236,7 @@ const providers: Array<IProvider> = [
 
 const customClient: Client = await ClientFactory.createCustomClient(
   providers,
+  chainId,
   true, // retry failed requests
   baseAccount // optional parameter
 );

--- a/docs/build/massa-web3/massa-web3.mdx
+++ b/docs/build/massa-web3/massa-web3.mdx
@@ -146,7 +146,6 @@ You can easily initialize a client instance using the ClientFactory class:
 
 <Tabs>
 <TabItem value="mainnet-client" label="Mainnet" default>
-
 ```typescript
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
@@ -158,27 +157,9 @@ const testnetClient: Client = await ClientFactory.createDefaultClient(
   baseAccount // optional parameter
 );
 ```
-
-</TabItem>
-
-<TabItem value="testnet-client" label="Testnet" default>
-
-```typescript
-const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
-  privateKey
-);
-
-const testnetClient: Client = await ClientFactory.createDefaultClient(
-  DefaultProviderUrls.TESTNET,
-  true, // retry failed requests
-  baseAccount // optional parameter
-);
-```
-
 </TabItem>
 
 <TabItem value="buildnet-client" label="Buildnet" default>
-
 ```typescript
 const baseAccount: IAccount = await WalletClient.getAccountFromSecretKey(
   privateKey
@@ -190,7 +171,6 @@ const testnetClient: Client = await ClientFactory.createDefaultClient(
   baseAccount // optional parameter
 );
 ```
-
 </TabItem>
 
 <TabItem value="labnet-client" label="Labnet" default>

--- a/docs/build/networks-faucets/local-network.mdx
+++ b/docs/build/networks-faucets/local-network.mdx
@@ -70,7 +70,12 @@ Setup your node to use the secret you just generated as its public key and staki
     {}
     ```
 
-- optionally, if you need a non-standard configuration, you can modify the file `massa-node/base_config/config.toml` depending on what you are trying to do.
+- You also have to modify the file `massa-node/base_config/config.toml` to match the same ChainID as a Sandbox node, as it defaults to the Mainnet ChainID of 77658377.
+    ```javascript
+    {
+        chain_id = 77
+    }
+    ```
 
 You can now launch your node:
 ```bash

--- a/docs/build/networks-faucets/public-networks.mdx
+++ b/docs/build/networks-faucets/public-networks.mdx
@@ -12,6 +12,25 @@ import VersionsTable from "@site/src/components/versions-table";
 Here's a handy table containing all you need to know about the different Massa networks and their faucets.
 
 <Tabs>
+  <TabItem value="mainnet" label="👷 MainNet" default>
+    <table>
+      <tr>
+        <td>🔗 Public API</td>
+        <td>
+          <a href="https://mainnet.massa.net/api/v2">
+            https://mainnet.massa.net/api/v2
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>🕵️ Explorer</td>
+        <td>
+          <a href="https://explorer.massa.net">https://explorer.massa.net</a>
+        </td>
+      </tr>
+    </table>
+  </TabItem>
+
   <TabItem value="buildnet" label="👷 BuildNet" default>
     <table>
       <tr>
@@ -61,6 +80,10 @@ Faucets play a crucial role in the blockchain ecosystem:
 - they also aid developers in testing and building blockchain applications by providing the necessary tokens for experimentation.
 
 ## What's Special About These Networks?
+
+### Mainnet
+
+The Massa Mainnet is the main network. It is the only Massa network for which MAS has a monetary value. As a result, no faucet is available for the Mainnet.
 
 ### Buildnet
 

--- a/docs/build/networks-faucets/public-networks.mdx
+++ b/docs/build/networks-faucets/public-networks.mdx
@@ -12,7 +12,7 @@ import VersionsTable from "@site/src/components/versions-table";
 Here's a handy table containing all you need to know about the different Massa networks and their faucets.
 
 <Tabs>
-  <TabItem value="mainnet" label="👷 MainNet" default>
+  <TabItem value="mainnet" label="🖥 MainNet" default>
     <table>
       <tr>
         <td>🔗 Public API</td>

--- a/docs/node/all-configs.mdx
+++ b/docs/node/all-configs.mdx
@@ -21,7 +21,7 @@ the `massa-node/config/config.toml` file.
 <!-- The content will be added at build time via ./scripts/download-configs.sh -->
 <Tabs>
 
-  <TabItem value="mainnet" label="👷 MainNet" default>
+  <TabItem value="mainnet" label="🖥 MainNet" default>
 ```toml
 EXTERNAL_MAINNET_NODE_CONFIG_CONTENT
 ```
@@ -41,7 +41,7 @@ the `massa-client/config/config.toml` file.
 
 <!-- The content will be added at build time via ./scripts/download-configs.sh -->
 <Tabs>
-  <TabItem value="mainnet" label="👷 MainNet" default>
+  <TabItem value="mainnet" label="🖥 MainNet" default>
 ```toml
 EXTERNAL_MAINNET_CLIENT_CONFIG_CONTENT
 ```

--- a/docs/node/all-configs.mdx
+++ b/docs/node/all-configs.mdx
@@ -20,13 +20,17 @@ the `massa-node/config/config.toml` file.
 
 <!-- The content will be added at build time via ./scripts/download-configs.sh -->
 <Tabs>
-  <TabItem value="buildnet" label="👷 BuildNet" default>
 
+  <TabItem value="mainnet" label="👷 MainNet" default>
+```toml
+EXTERNAL_MAINNET_NODE_CONFIG_CONTENT
+```
+  </TabItem>
+
+  <TabItem value="buildnet" label="👷 BuildNet" default>
 ```toml
 EXTERNAL_BUILDNET_NODE_CONFIG_CONTENT
-
 ```
-
   </TabItem>
 </Tabs>
 
@@ -37,12 +41,15 @@ the `massa-client/config/config.toml` file.
 
 <!-- The content will be added at build time via ./scripts/download-configs.sh -->
 <Tabs>
-  <TabItem value="buildnet" label="👷 BuildNet" default>
+  <TabItem value="mainnet" label="👷 MainNet" default>
+```toml
+EXTERNAL_MAINNET_CLIENT_CONFIG_CONTENT
+```
+  </TabItem>
 
+  <TabItem value="buildnet" label="👷 BuildNet" default>
 ```toml
 EXTERNAL_BUILDNET_CLIENT_CONFIG_CONTENT
-
 ```
-
   </TabItem>
 </Tabs>

--- a/docs/node/check_status.mdx
+++ b/docs/node/check_status.mdx
@@ -1,0 +1,20 @@
+---
+id: check_status
+sidebar_label: Check your node's status
+---
+
+# Check your node's status
+
+## Check your routability status
+
+You can use a service such as https://portchecker.co to check that the ports 31244 and 31245 are both opened for your public IP address.
+
+Additionally, in your massa-client, you can check that the `get_status` command shows your `Node's IP: <your_public_ip_address>`.
+If it shows `No routable IP set` instead, please check again your configuration.
+
+## Make sure you are connected to peers
+
+In order for your node to be running properly, you have to make sure you are connected to other peers on the network.
+
+The `get_status` command will show you which nodes you are connected too.
+You need to have both IN and OUT connections.

--- a/docs/node/initial.mdx
+++ b/docs/node/initial.mdx
@@ -49,6 +49,7 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - set it as default: ```rustup default 1.74.1```
 - check rust version: ```rustc --version```
 - clone this repo: ```git clone https://github.com/massalabs/massa.git```
+- build the code: ```cd massa``` and ```cargo build --release```
 
 #### On Windows
 
@@ -70,6 +71,7 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - Open Windows Power Shell
     - Clone the latest distributed version: ```git clone https://github.com/massalabs/massa.git```
     - Change default Rust to the following stable version: ```rustup default 1.74.1```
+    - Build the code: ```cd massa``` and ```cargo build --release```
 
 ## Step 2: Configuration
 

--- a/docs/node/initial.mdx
+++ b/docs/node/initial.mdx
@@ -49,7 +49,6 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - set it as default: ```rustup default 1.74.1```
 - check rust version: ```rustc --version```
 - clone this repo: ```git clone https://github.com/massalabs/massa.git```
-- build the code: ```cd massa``` and ```cargo build --release```
 
 #### On Windows
 
@@ -71,7 +70,6 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - Open Windows Power Shell
     - Clone the latest distributed version: ```git clone https://github.com/massalabs/massa.git```
     - Change default Rust to the following stable version: ```rustup default 1.74.1```
-    - Build the code: ```cd massa``` and ```cargo build --release```
 
 ## Step 2: Configuration
 

--- a/docs/node/initial.mdx
+++ b/docs/node/initial.mdx
@@ -28,11 +28,11 @@ More info in the [FAQ](/docs/node/faq).
 
 If you just wish to run a Massa node without compiling it yourself, you can simply download the latest binary below:
 
-- [Windows executable](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_windows.zip)
-- [Linux binary](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_linux.tar.gz) - 
+- [Windows executable](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_windows.zip)
+- [Linux binary](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_linux.tar.gz) - 
 only works with libc2.28 and higher (for example Ubuntu 20.04 and higher)
-- [MacOS binary](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_macos_aarch64.tar.gz)
-- Other binaries can be found on https://github.com/massalabs/massa/releases/tag/MAIN.1.0
+- [MacOS binary](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_macos_aarch64.tar.gz)
+- Other binaries can be found on https://github.com/massalabs/massa/releases/tag/MAIN.2.0
 
 ### Installing from source code (advanced installation)
 

--- a/docs/node/install.mdx
+++ b/docs/node/install.mdx
@@ -60,8 +60,8 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
     - Clone the latest distributed version: ```git clone https://github.com/massalabs/massa.git```
     - Change default Rust to the following stable version: ```rustup default 1.74.1```
 
-
 ## My node is installed. What next ?
 
 Once you have installed your node, you want to set it up for running and staking.
-Please follow the next step: [Running a node](/docs/node/run).
+Before running the node, you should configure it to be routable as indicated [here](routability#how-to-make-your-node-routable).
+Without it, your node will be unstable through lack of connectivity.

--- a/docs/node/install.mdx
+++ b/docs/node/install.mdx
@@ -38,6 +38,7 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - set it as default: ```rustup default 1.74.1```
 - check rust version: ```rustc --version```
 - clone this repo: ```git clone https://github.com/massalabs/massa.git```
+- build the code: ```cargo build --release```
 
 ### On Windows
 
@@ -59,6 +60,7 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - Open Windows Power Shell
     - Clone the latest distributed version: ```git clone https://github.com/massalabs/massa.git```
     - Change default Rust to the following stable version: ```rustup default 1.74.1```
+    - Build the code: ```cargo build --release```
 
 ## My node is installed. What next ?
 

--- a/docs/node/install.mdx
+++ b/docs/node/install.mdx
@@ -17,11 +17,11 @@ More info in the [FAQ](/docs/node/faq).
 If you just wish to run a Massa node without compiling it yourself, you can simply download the latest binary below and
 go to the next step: [Running a node](/docs/node/run).
 
-- [Windows executable](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_windows.zip)
-- [Linux binary](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_linux.tar.gz) - 
+- [Windows executable](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_windows.zip)
+- [Linux binary](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_linux.tar.gz) - 
 only works with libc2.28 and higher (for example Ubuntu 20.04 and higher)
-- [MacOS binary](https://github.com/massalabs/massa/releases/download/MAIN.1.0/massa_MAIN.1.0_release_macos_aarch64.tar.gz)
-- Other binaries can be found on https://github.com/massalabs/massa/releases/tag/MAIN.1.0
+- [MacOS binary](https://github.com/massalabs/massa/releases/download/MAIN.2.0/massa_MAIN.2.0_release_macos_aarch64.tar.gz)
+- Other binaries can be found on https://github.com/massalabs/massa/releases/tag/MAIN.2.0
 
 ## From source code (advanced installation)
 

--- a/docs/node/install.mdx
+++ b/docs/node/install.mdx
@@ -38,7 +38,6 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - set it as default: ```rustup default 1.74.1```
 - check rust version: ```rustc --version```
 - clone this repo: ```git clone https://github.com/massalabs/massa.git```
-- build the code: ```cargo build --release```
 
 ### On Windows
 
@@ -60,7 +59,6 @@ Otherwise, if you wish to run a Massa node from source code, here are the steps 
 - Open Windows Power Shell
     - Clone the latest distributed version: ```git clone https://github.com/massalabs/massa.git```
     - Change default Rust to the following stable version: ```rustup default 1.74.1```
-    - Build the code: ```cargo build --release```
 
 ## My node is installed. What next ?
 

--- a/docs/node/run.mdx
+++ b/docs/node/run.mdx
@@ -135,7 +135,7 @@ reports of the same error.
 
 ## What next ?
 
-Congratulations, you are now running a node.
-But your node is still not staking, so it is not producing blocks nor receiving rewards.
+Congratulations, you are now running a node. To interact with the network, to send transactions and call smart contracts,
+you will need a wallet.
 
-It is time to activate staking on your node. Follow the tutorial: [Staking with a node](/docs/node/stake).
+It is time to setup or import a wallet. Follow the tutorial: [Creating a wallet](/docs/node/wallet).

--- a/docs/node/stake.mdx
+++ b/docs/node/stake.mdx
@@ -88,3 +88,9 @@ them, again check with:
 ```shell
 wallet_info
 ```
+
+## What next ?
+
+Congratulations, you followed all the steps to be part of the Massa adventure!
+
+You should now check the status of your setup: [Check your node's status](/docs/node/check_status).

--- a/docs/node/wallet.mdx
+++ b/docs/node/wallet.mdx
@@ -61,3 +61,10 @@ Access secret key(s) of addresse(s):
 ```shell
 wallet_get_secret_key <Address1> <Address2>
 ```
+
+## What next ?
+
+Congratulations, you are now running a node and have access to a wallet.
+But your node is still not staking, so it is not producing blocks nor receiving rewards.
+
+It is time to activate staking on your node. Follow the tutorial: [Staking with a node](/docs/node/stake).

--- a/docs/node/wallet.mdx
+++ b/docs/node/wallet.mdx
@@ -5,7 +5,7 @@ sidebar_label: Creating a wallet
 
 # Creating a Massa wallet
 
-In this tutorial you will learn how to create a Massa wallet.
+In this tutorial you will learn how to create or import a Massa wallet.
 
 A wallet is a file that contains a list of keypairs. Like other blockchains, Massa uses elliptic curve cryptography
 (specifically ed25519) to secure your coins. It means that your secret key is your password allowing you to spend coins
@@ -38,12 +38,6 @@ Now you can either generate a new keypair (and associated address):
 wallet_generate_secret_key
 ```
 
-Or, if you already have one from a previous wallet, you can add manually an existing keypair:
-
-```shell
-wallet_add_secret_keys <SecretKey>
-```
-
 The list of addresses of your wallet can be accessed with:
 
 ```shell
@@ -61,6 +55,22 @@ Access secret key(s) of addresse(s):
 ```shell
 wallet_get_secret_key <Address1> <Address2>
 ```
+
+# Importing your wallet in the client
+
+In order to import a wallet into your client, the procedure depends on how you have saved your wallet in the first place.
+
+## If you have saved your secret/private key
+
+Then you can import it in the client using the following command:
+```shell
+wallet_add_secret_keys <your_secret_key>
+```
+
+## If you have saved an encrypted wallet file
+
+Then you can import it in the client by placing the corresponding `.yaml` file in the `massa/massa-client/wallets` folder.
+Make sure it is the only wallet in the folder.
 
 ## What next ?
 

--- a/external/client/mainnet/config-files.txt
+++ b/external/client/mainnet/config-files.txt
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/massalabs/massa/mainnet/massa-client/base_config/config.toml

--- a/external/node/mainnet/config-files.txt
+++ b/external/node/mainnet/config-files.txt
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/massalabs/massa/mainnet/massa-node/base_config/config.toml

--- a/scripts/download-configs.sh
+++ b/scripts/download-configs.sh
@@ -41,25 +41,25 @@ insert_content() {
 # Start of the script
 echo "Script started: Download config files"
 
-# Download node and client config files
+# Download node and client config files for mainnet
+download_files "./external/node/mainnet/" "./external/node/mainnet/config-files.txt"
+download_files "./external/client/mainnet/" "./external/client/mainnet/config-files.txt"
+
+# Add node config file content to the documentation for mainnet
+insert_content "EXTERNAL_MAINNET_NODE_CONFIG_CONTENT" "./external/node/mainnet/config.toml" "./docs/node/all-configs.mdx"
+
+# Add client config file content to the documentation for mainnet
+insert_content "EXTERNAL_MAINNET_CLIENT_CONFIG_CONTENT" "./external/client/mainnet/config.toml" "./docs/node/all-configs.mdx"
+
+# Download node and client config files for buildnet
 download_files "./external/node/buildnet/" "./external/node/buildnet/config-files.txt"
 download_files "./external/client/buildnet/" "./external/client/buildnet/config-files.txt"
 
-# Add node config file content to the documentation
+# Add node config file content to the documentation for buildnet
 insert_content "EXTERNAL_BUILDNET_NODE_CONFIG_CONTENT" "./external/node/buildnet/config.toml" "./docs/node/all-configs.mdx"
 
-# Add client config file content to the documentation
+# Add client config file content to the documentation for buildnet
 insert_content "EXTERNAL_BUILDNET_CLIENT_CONFIG_CONTENT" "./external/client/buildnet/config.toml" "./docs/node/all-configs.mdx"
-
-# Download node and client config files
-download_files "./external/node/testnet/" "./external/node/testnet/config-files.txt"
-download_files "./external/client/testnet/" "./external/client/testnet/config-files.txt"
-
-# Add node config file content to the documentation
-insert_content "EXTERNAL_TESTNET_NODE_CONFIG_CONTENT" "./external/node/testnet/config.toml" "./docs/node/all-configs.mdx"
-
-# Add client config file content to the documentation
-insert_content "EXTERNAL_TESTNET_CLIENT_CONFIG_CONTENT" "./external/client/testnet/config.toml" "./docs/node/all-configs.mdx"
 
 # Script completed successfully
 echo "Script finished: Config files downloaded and inserted into documentation."

--- a/sidebars.js
+++ b/sidebars.js
@@ -376,6 +376,11 @@ const sidebars = {
     },
     {
       type: "doc",
+      id: "node/routability",
+      label: "Routability",
+    },
+    {
+      type: "doc",
       id: "node/run",
       label: "Running a node",
     },
@@ -388,11 +393,6 @@ const sidebars = {
       type: "doc",
       id: "node/stake",
       label: "Staking",
-    },
-    {
-      type: "doc",
-      id: "node/routability",
-      label: "Routability",
     },
     {
       type: "doc",

--- a/sidebars.js
+++ b/sidebars.js
@@ -396,6 +396,11 @@ const sidebars = {
     },
     {
       type: "doc",
+      id: "node/check_status",
+      label: "Checking the node's status",
+    },
+    {
+      type: "doc",
       id: "node/all-configs",
       label: "Node and client configuration",
     },

--- a/src/components/versions-table.tsx
+++ b/src/components/versions-table.tsx
@@ -25,7 +25,7 @@ export default function VersionsTable() {
   const versionsData: VersionsData = versions;
 
   return (
-    <Tabs defaultValue="Buildnet">
+    <Tabs defaultValue="Mainnet">
       {versionsData.networks.map((network) => (
         <TabItem value={network} label={network} key={network}>
           <table>

--- a/static/json/versions-tooling.json
+++ b/static/json/versions-tooling.json
@@ -1,11 +1,12 @@
 {
   "title": "Massa Tools Versions Compatibilities",
-  "networks": ["Buildnet"],
+  "networks": ["Mainnet", "Buildnet"],
   "projects": [
     {
       "title": "sc-project-initializer",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/project-initializer",
       "npmLink": "https://www.npmjs.com/package/@massalabs/sc-project-initializer?activeTab=versions"
@@ -13,7 +14,8 @@
     {
       "title": "massa-as-sdk",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/massa-as-sdk",
       "npmLink": "https://www.npmjs.com/package/@massalabs/massa-as-sdk?activeTab=versions"
@@ -21,7 +23,8 @@
     {
       "title": "massa-web3",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/massa-web3",
       "npmLink": "https://www.npmjs.com/package/@massalabs/massa-web3?activeTab=versions"
@@ -29,7 +32,8 @@
     {
       "title": "wallet-provider",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/wallet-provider",
       "npmLink": "https://www.npmjs.com/package/@massalabs/wallet-provider?activeTab=versions"
@@ -37,7 +41,8 @@
     {
       "title": "as-types",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/as-types",
       "npmLink": "https://www.npmjs.com/package/@massalabs/as-types?activeTab=versions"
@@ -45,7 +50,8 @@
     {
       "title": "as-proba",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/as-proba",
       "npmLink": "https://www.npmjs.com/package/@massalabs/as-proba?activeTab=versions"
@@ -53,7 +59,8 @@
     {
       "title": "as-transformer",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/as-transformer",
       "npmLink": "https://www.npmjs.com/package/@massalabs/as-transformer?activeTab=versions"
@@ -61,7 +68,8 @@
     {
       "title": "sc-deployer",
       "compatibilities": [
-        { "network": "Buildnet", "version": "buildnet" }
+        { "network": "Buildnet", "version": "buildnet" },
+        { "network": "Mainnet", "version": "mainnet" }
       ],
       "install": "npm install @massalabs/massa-sc-deployer",
       "npmLink": "https://www.npmjs.com/package/@massalabs/massa-sc-deployer?activeTab=versions"


### PR DESCRIPTION
Related to: https://github.com/massalabs/docs/issues/254

DONE:
- [x] Add Mainnet config and tabs when relevant
- [x] Add Mainnet description in Public-Networks
- [x] Put ChainId doc in sandbox node page
- [x] Refactored a bit the node running guide (for normal node runners)

TODO for initial node runners:
- [ ] make sure everything is working if we follow the steps described in docs/node/initial.mdx
- [ ] proof-read everything

TODO for normal node runners:
- [x] fill the TODOs on how to import saved wallets
- [x] add node routability setup at node install phase. Insist that without routability, their node will be unstable through lack of connectivity
  - [x] for routability, DO NOT FORGET TO SET THE IP ADDRESS IN THE CONFIG
  - [x] tell how to check that it is defined (eg. I think the client tells you your IP address on top of get_info (?))
- [x] check that all links work
- [x] try to render and see how it looks
- [x] add a last phase where you check the status of your node:
  - [x] routability check using an external service like https://portchecker.co/
  - [x] make sure your node is connected to peers
- [ ] make sure everything is working if we follow the steps described in docs/node/home.mdx
- [ ] proof-read everything